### PR TITLE
Fix meta tags for Yandex indexing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ru">
   <head>
+    <!--ssr-head-->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && tsx scripts/prerender.ts && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "vercel-build": "npm run build",
     "check": "tsc",

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import pages from '../client/src/config/pages.json' with { type: 'json' };
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+interface Page { slug: string; title: string; description: string; }
+
+const extraPages: Page[] = [
+  {
+    slug: 'faq',
+    title: 'Часто задаваемые вопросы об оптимизации изображений — ImageNinja',
+    description:
+      'Ответы на часто задаваемые вопросы о сервисе оптимизации изображений ImageNinja. Узнайте как сжимать изображения без потери качества, конвертировать форматы и многое другое.',
+  },
+];
+
+function injectMeta(html: string, page: Page): string {
+  const baseUrl = 'https://imageninja.ru';
+  const pageUrl = `${baseUrl}${page.slug ? `/${page.slug}` : '/'}`;
+  const meta = `\n      <title>${page.title}</title>\n      <meta name="description" content="${page.description}" />\n      <link rel="canonical" href="${pageUrl}" />\n      <meta property="og:type" content="website" />\n      <meta property="og:locale" content="ru_RU" />\n      <meta property="og:site_name" content="ImageNinja" />\n      <meta property="og:title" content="${page.title}" />\n      <meta property="og:description" content="${page.description}" />\n      <meta property="og:url" content="${pageUrl}" />\n      <meta property="og:image" content="${baseUrl}/assets/images/seo-cover.webp" />\n      <meta name="twitter:card" content="summary_large_image" />\n      <meta name="twitter:title" content="${page.title}" />\n      <meta name="twitter:description" content="${page.description}" />\n      <meta name="twitter:image" content="${baseUrl}/assets/images/seo-cover.webp" />`;
+  return html.replace('<!--ssr-head-->', meta);
+}
+
+const distDir = path.resolve(__dirname, '../dist/public');
+const template = fs.readFileSync(path.join(distDir, 'index.html'), 'utf8');
+
+const allPages: Page[] = [...(pages as Page[]), ...extraPages];
+for (const page of allPages) {
+  const html = injectMeta(template, page);
+  const filePath = page.slug ? path.join(distDir, page.slug, 'index.html') : path.join(distDir, 'index.html');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, html, 'utf8');
+}

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -21,8 +21,9 @@ export function log(message: string, source = "express") {
 }
 
 function injectMeta(html: string, pathname: string): string {
-  // Normalize path, removing leading and trailing slashes
-  const normalized = pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+  // Normalize and decode the path, removing leading/trailing slashes
+  const decoded = decodeURIComponent(pathname);
+  const normalized = decoded.replace(/^\/+/, "").replace(/\/+$/, "");
   const slug = normalized === "" ? "" : normalized;
   let page: any = (pages as any[]).find((p) => p.slug === slug);
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -21,7 +21,9 @@ export function log(message: string, source = "express") {
 }
 
 function injectMeta(html: string, pathname: string): string {
-  const slug = pathname === "/" ? "" : pathname.replace(/^\//, "");
+  // Normalize path, removing leading and trailing slashes
+  const normalized = pathname.replace(/^\/+/, "").replace(/\/+$/, "");
+  const slug = normalized === "" ? "" : normalized;
   let page: any = (pages as any[]).find((p) => p.slug === slug);
 
   if (slug === "faq") {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -5,6 +5,7 @@ import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
+import pages from "../client/src/config/pages.json" assert { type: "json" };
 
 const viteLogger = createLogger();
 
@@ -17,6 +18,29 @@ export function log(message: string, source = "express") {
   });
 
   console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+function injectMeta(html: string, pathname: string): string {
+  const slug = pathname === "/" ? "" : pathname.replace(/^\//, "");
+  let page: any = (pages as any[]).find((p) => p.slug === slug);
+
+  if (slug === "faq") {
+    page = {
+      slug: "faq",
+      title: "Часто задаваемые вопросы об оптимизации изображений — ImageNinja",
+      description:
+        "Ответы на часто задаваемые вопросы о сервисе оптимизации изображений ImageNinja. Узнайте как сжимать изображения без потери качества, конвертировать форматы и многое другое.",
+    };
+  }
+
+  if (!page) return html.replace("<!--ssr-head-->", "");
+
+  const baseUrl = "https://imageninja.ru";
+  const pageUrl = `${baseUrl}${page.slug ? `/${page.slug}` : "/"}`;
+
+  const meta = `\n      <title>${page.title}</title>\n      <meta name="description" content="${page.description}" />\n      <link rel="canonical" href="${pageUrl}" />\n      <meta property="og:type" content="website" />\n      <meta property="og:locale" content="ru_RU" />\n      <meta property="og:site_name" content="ImageNinja" />\n      <meta property="og:title" content="${page.title}" />\n      <meta property="og:description" content="${page.description}" />\n      <meta property="og:url" content="${pageUrl}" />\n      <meta property="og:image" content="${baseUrl}/assets/images/seo-cover.webp" />\n      <meta name="twitter:card" content="summary_large_image" />\n      <meta name="twitter:title" content="${page.title}" />\n      <meta name="twitter:description" content="${page.description}" />\n      <meta name="twitter:image" content="${baseUrl}/assets/images/seo-cover.webp" />`;
+
+  return html.replace("<!--ssr-head-->", meta);
 }
 
 export async function setupVite(app: Express, server: Server) {
@@ -32,7 +56,7 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  
+
   app.get(/^(?!\/api\/).*$/, async (req, res, next) => {
     const url = req.originalUrl;
 
@@ -47,7 +71,9 @@ export async function setupVite(app: Express, server: Server) {
       );
 
       template = await vite.transformIndexHtml(url, template);
-      
+
+      template = injectMeta(template, req.path);
+
       res.status(200).set({ "Content-Type": "text/html" }).end(template);
     } catch (e) {
       vite.ssrFixStacktrace(e as Error);
@@ -68,7 +94,9 @@ export function serveStatic(app: Express) {
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
+  app.use("*", (req, res) => {
+    const template = fs.readFileSync(path.resolve(distPath, "index.html"), "utf-8");
+    const html = injectMeta(template, req.path);
+    res.send(html);
   });
 }


### PR DESCRIPTION
## Summary
- add placeholder in `index.html` for server-side meta tags
- inject meta tags for each slug in server

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6843cfc5ddac8327a149563e2d9378c4