### PR TITLE
Fix react-helmet-async imports in pages

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,8 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import { HelmetProvider } from "react-helmet-async";
+import pkg from "react-helmet-async";
+const { HelmetProvider } = pkg;
 
 createRoot(document.getElementById("root")!).render(
   <HelmetProvider>

--- a/client/src/pages/FaqPage.tsx
+++ b/client/src/pages/FaqPage.tsx
@@ -4,7 +4,8 @@
  * @dependencies: react, Helmet
  * @created: 2024-06-07
  */
-import { Helmet } from 'react-helmet-async';
+import pkg from 'react-helmet-async';
+const { Helmet } = pkg;
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { YandexAds } from '@/components/YandexAds';

--- a/client/src/pages/OptimizePageRouter.tsx
+++ b/client/src/pages/OptimizePageRouter.tsx
@@ -4,7 +4,8 @@
  * @dependencies: wouter, react-helmet-async, pages.config.ts, OptimizePage, NotFound
  * @created: 2024-06-05
  */
-import { Helmet } from 'react-helmet-async'
+import pkg from 'react-helmet-async';
+const { Helmet } = pkg;
 import { pages, getPages } from '@/config/pages.config'
 import { OptimizePage } from '@/components/OptimizePage'
 import { Header } from '@/components/Header'

--- a/client/src/pages/image-optimizer.tsx
+++ b/client/src/pages/image-optimizer.tsx
@@ -4,7 +4,8 @@
  * @dependencies: OptimizePage, Helmet, pages.config.ts
  * @created: 2024-06-05
  */
-import { Helmet } from 'react-helmet-async'
+import pkg from 'react-helmet-async';
+const { Helmet } = pkg;
 import { pages, getPages } from '@/config/pages.config'
 import { OptimizePage } from '@/components/OptimizePage'
 import { useEffect, useState } from 'react'


### PR DESCRIPTION
## Summary
- import `Helmet` and `HelmetProvider` via default package
- refactor pages to use the new import style

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68442c5259408327afb4ca02e22ac3c8