### PR TITLE
Fix react-helmet-async imports

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,8 +9,7 @@ import { YM_COUNTER_ID } from "@/lib/yandex-metrika";
 import FaqPage from "@/pages/FaqPage";
 import DonateSuccessPage from './pages/donate-success'
 import pages from "./config/pages.json";
-import pkg from "react-helmet-async";
-const { Helmet } = pkg;
+import { Helmet } from "react-helmet-async";
 
 // Добавляем типы для Яндекс Метрики
 declare global {

--- a/client/src/entry-server.tsx
+++ b/client/src/entry-server.tsx
@@ -8,8 +8,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { Router } from 'wouter';
-import pkg from 'react-helmet-async';
-const { HelmetProvider } = pkg;
+import { HelmetProvider } from 'react-helmet-async';
 import type { HelmetServerState } from 'react-helmet-async';
 
 import App from './App'; // Ваш главный компонент-роутер теперь импортируется как App

--- a/client/src/pages/OptimizePageRouter.tsx
+++ b/client/src/pages/OptimizePageRouter.tsx
@@ -4,7 +4,7 @@
  * @dependencies: wouter, react-helmet-async, pages.config.ts, OptimizePage, NotFound
  * @created: 2024-06-05
  */
-import { Helmet } from 'react-helmet-async'
+import { Helmet } from 'react-helmet-async';
 import { pages, getPages } from '@/config/pages.config'
 import { OptimizePage } from '@/components/OptimizePage'
 import { Header } from '@/components/Header'

--- a/client/src/pages/image-optimizer.tsx
+++ b/client/src/pages/image-optimizer.tsx
@@ -4,7 +4,7 @@
  * @dependencies: OptimizePage, Helmet, pages.config.ts
  * @created: 2024-06-05
  */
-import { Helmet } from 'react-helmet-async'
+import { Helmet } from 'react-helmet-async';
 import { pages, getPages } from '@/config/pages.config'
 import { OptimizePage } from '@/components/OptimizePage'
 import { useEffect, useState } from 'react'


### PR DESCRIPTION
## Summary
- revert `react-helmet-async` imports to use named exports

## Testing
- `npm ci`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68442c5259408327afb4ca02e22ac3c8