### PR TITLE
Fix react-helmet-async imports

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,8 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import pkg from "react-helmet-async";
-const { HelmetProvider } = pkg;
+import { HelmetProvider } from "react-helmet-async";
 
 createRoot(document.getElementById("root")!).render(
   <HelmetProvider>

--- a/client/src/pages/FaqPage.tsx
+++ b/client/src/pages/FaqPage.tsx
@@ -4,8 +4,7 @@
  * @dependencies: react, Helmet
  * @created: 2024-06-07
  */
-import pkg from 'react-helmet-async';
-const { Helmet } = pkg;
+import { Helmet } from 'react-helmet-async';
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';
 import { YandexAds } from '@/components/YandexAds';


### PR DESCRIPTION
## Summary
- fix `FaqPage` to use named Helmet import
- use named HelmetProvider import in client entry

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68444ea58a9c8327906a79e557750028