### PR TITLE
Fix react-helmet-async for SSR

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,7 +9,8 @@ import { YM_COUNTER_ID } from "@/lib/yandex-metrika";
 import FaqPage from "@/pages/FaqPage";
 import DonateSuccessPage from './pages/donate-success'
 import pages from "./config/pages.json";
-import { Helmet } from "react-helmet-async";
+import pkg from "react-helmet-async/lib/index.js";
+const { Helmet } = pkg;
 
 // Добавляем типы для Яндекс Метрики
 declare global {

--- a/client/src/entry-server.tsx
+++ b/client/src/entry-server.tsx
@@ -8,7 +8,8 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { Router } from 'wouter';
-import { HelmetProvider } from 'react-helmet-async';
+import pkg from 'react-helmet-async/lib/index.js';
+const { HelmetProvider } = pkg;
 import type { HelmetServerState } from 'react-helmet-async';
 
 import App from './App'; // Ваш главный компонент-роутер теперь импортируется как App

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import pkg from "react-helmet-async";
+import pkg from "react-helmet-async/lib/index.js";
 const { HelmetProvider } = pkg;
 
 createRoot(document.getElementById("root")!).render(

--- a/client/src/pages/FaqPage.tsx
+++ b/client/src/pages/FaqPage.tsx
@@ -4,7 +4,7 @@
  * @dependencies: react, Helmet
  * @created: 2024-06-07
  */
-import pkg from 'react-helmet-async';
+import pkg from 'react-helmet-async/lib/index.js';
 const { Helmet } = pkg;
 import { Footer } from '@/components/Footer';
 import { Header } from '@/components/Header';

--- a/client/src/pages/OptimizePageRouter.tsx
+++ b/client/src/pages/OptimizePageRouter.tsx
@@ -5,7 +5,8 @@
  * @created: 2024-06-05
  */
 
-import { Helmet } from 'react-helmet-async';
+import pkg from 'react-helmet-async/lib/index.js';
+const { Helmet } = pkg;
 import { pages, getPages } from '@/config/pages.config'
 import { OptimizePage } from '@/components/OptimizePage'
 import { Header } from '@/components/Header'

--- a/client/src/pages/image-optimizer.tsx
+++ b/client/src/pages/image-optimizer.tsx
@@ -5,7 +5,8 @@
  * @created: 2024-06-05
  */
 
-import { Helmet } from 'react-helmet-async';
+import pkg from 'react-helmet-async/lib/index.js';
+const { Helmet } = pkg;
 import { pages, getPages } from '@/config/pages.config'
 import { OptimizePage } from '@/components/OptimizePage'
 import { useEffect, useState } from 'react'

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -84,7 +84,7 @@ export function serveStatic(app: Express) {
     );
   }
 
-  app.use(express.static(distPath));
+  app.use(express.static(distPath, { index: false }));
 
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;


### PR DESCRIPTION
## Summary
- import CJS build of `react-helmet-async`
- prevent static middleware from serving index.html so Helmet tags are injected

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68444ea58a9c8327906a79e557750028