### PR TITLE
Add basic Next.js setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.next
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ npm run build
 npm run start
 ```
 
+### Next.js приложение
+
+Для запуска экспериментальной версии на Next.js используйте:
+
+```bash
+npm run next:dev
+```
+
+Сборка и запуск в production:
+
+```bash
+npm run next:build
+npm run next:start
+```
+
 ## Структура проекта
 
 - `client/` - Frontend часть приложения (React)

--- a/next-app/app/layout.tsx
+++ b/next-app/app/layout.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ru">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+export default function Home() {
+  return <h1>Next.js приложение</h1>
+}

--- a/next-app/next-env.d.ts
+++ b/next-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-app/next.config.mjs
+++ b/next-app/next.config.mjs
@@ -1,0 +1,3 @@
+const nextConfig = {}
+
+export default nextConfig

--- a/next-app/tsconfig.json
+++ b/next-app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "app/**/*",
+    ".next/types/**/*.ts"
+  ],
+  "compilerOptions": {
+    "target": "ES2017",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "docker:build": "docker build -t sharp-optimizer .",
-    "docker:run": "docker run -p 3000:3000 sharp-optimizer"
+    "docker:run": "docker run -p 3000:3000 sharp-optimizer",
+    "next:dev": "next dev ./next-app",
+    "next:build": "next build ./next-app",
+    "next:start": "next start ./next-app"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- set up an empty Next.js app under `next-app/`
- add dev/build/start scripts for Next.js
- document how to run the experimental Next.js version
- ignore build output

## Testing
- `npm run check`
- `npm run next:build`

------
https://chatgpt.com/codex/tasks/task_e_6847f22e683c83278af18772a1e529c0